### PR TITLE
use modern perl's xs api/partial ithread fixes/loop performance fixes

### DIFF
--- a/Check.xs
+++ b/Check.xs
@@ -1,3 +1,4 @@
+#define PERL_NO_GET_CONTEXT
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
@@ -71,6 +72,7 @@ check_cb (pTHX_ OP *op) {
 
 hook_op_check_id
 hook_op_check (opcode type, hook_op_check_cb cb, void *user_data) {
+	dTHX;
 	AV *hooks;
 	SV *hook;
 
@@ -91,6 +93,7 @@ hook_op_check (opcode type, hook_op_check_cb cb, void *user_data) {
 
 void *
 hook_op_check_remove (opcode type, hook_op_check_id id) {
+	dTHXa(NULL);;
 	AV *hooks;
 	I32 i;
 	void *ret = NULL;
@@ -101,6 +104,7 @@ hook_op_check_remove (opcode type, hook_op_check_id id) {
 		return NULL;
 	}
 
+	aTHXa(PERL_GET_THX);
 	for (i = 0; i <= av_len (hooks); i++) {
 		SV **hook = av_fetch (hooks, i, 0);
 


### PR DESCRIPTION
this module isnt really ithread compatible since it is storing AV*s in C global storage which is forbidden, since the AV*s/SV*s can be alloced by different ithread instances/my_perl vars, and randomly dealloc, esp on Win32 with its own custom per ithread malloc that drops all the ithreads memory pool/CPU pages in 1 syscall, but not using #define NO_GET_CXT causing 100s of extra instances of call sites to Perl_get_context(), is my larger concern since that slows down threaded build perl interps any OS to keep calling that getter function 1000s/10Ks of times per minute, even when never loading `use threads; ` in PP space.